### PR TITLE
Add chart/table automation scripts and fixes

### DIFF
--- a/excel_charts_to_word.py
+++ b/excel_charts_to_word.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Copy Excel charts to bookmarks in a Word document."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+from gslide.excel_reader import _open_excel, _safe_close
+from gslide.word_writer import _open_word, paste_image_at_bookmark
+
+
+def export_chart(wb, sheet: str, chart_name: str) -> str:
+    """Export a chart as an EMF file and return the path."""
+    chart_obj = wb.Worksheets(sheet).ChartObjects(chart_name)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".emf") as tmp:
+        chart_obj.Chart.Export(tmp.name)
+        return tmp.name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Copy charts from Excel to Word")
+    parser.add_argument("--excel", required=True, help="Path to the Excel workbook")
+    parser.add_argument("--word", required=True, help="Path to the Word document")
+    parser.add_argument(
+        "--mapping",
+        action="append",
+        nargs=3,
+        metavar=("sheet", "chart", "bookmark"),
+        help="Sheet name, chart name, bookmark",
+    )
+    args = parser.parse_args()
+
+    excel_path = str(Path(args.excel).expanduser().resolve())
+    word_path = str(Path(args.word).expanduser().resolve())
+    mappings = args.mapping or []
+
+    xl, wb = _open_excel(excel_path)
+    word_app, doc = _open_word(word_path)
+    try:
+        for sheet, chart_name, bookmark in mappings:
+            img_path = export_chart(wb, sheet, chart_name)
+            try:
+                paste_image_at_bookmark(word_path, bookmark, img_path, word_app=word_app, doc=doc)
+            finally:
+                Path(img_path).unlink(missing_ok=True)
+        doc.Save()
+    finally:
+        doc.Close(False)
+        word_app.Quit()
+        _safe_close(xl, wb)
+
+
+if __name__ == "__main__":
+    main()

--- a/excel_tables_to_word.py
+++ b/excel_tables_to_word.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Copy Excel ranges (tables) to bookmarks in a Word document."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+from gslide.excel_reader import _open_excel, _safe_close
+from gslide.word_writer import _open_word, paste_image_at_bookmark
+
+
+XL_PICTURE = -4147
+XL_SCREEN = 1
+
+
+def export_range(wb, sheet: str, cell_range: str) -> str:
+    """Capture a range as an EMF file and return the path."""
+    sht = wb.Worksheets(sheet)
+    sht.Range(cell_range).CopyPicture(Appearance=XL_SCREEN, Format=XL_PICTURE)
+    chart = wb.Charts.Add()
+    chart.Paste()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".emf") as tmp:
+        chart.Export(tmp.name)
+    chart.Delete()
+    return tmp.name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Copy tables from Excel to Word")
+    parser.add_argument("--excel", required=True, help="Path to the Excel workbook")
+    parser.add_argument("--word", required=True, help="Path to the Word document")
+    parser.add_argument(
+        "--mapping",
+        action="append",
+        nargs=3,
+        metavar=("sheet", "range", "bookmark"),
+        help="Sheet name, range, bookmark",
+    )
+    args = parser.parse_args()
+
+    excel_path = str(Path(args.excel).expanduser().resolve())
+    word_path = str(Path(args.word).expanduser().resolve())
+    mappings = args.mapping or []
+
+    xl, wb = _open_excel(excel_path)
+    word_app, doc = _open_word(word_path)
+    try:
+        for sheet, rng, bookmark in mappings:
+            img_path = export_range(wb, sheet, rng)
+            try:
+                paste_image_at_bookmark(word_path, bookmark, img_path, word_app=word_app, doc=doc)
+            finally:
+                Path(img_path).unlink(missing_ok=True)
+        doc.Save()
+    finally:
+        doc.Close(False)
+        word_app.Quit()
+        _safe_close(xl, wb)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gslide/excel_reader.py
+++ b/src/gslide/excel_reader.py
@@ -8,7 +8,7 @@ code can stay tidy.  It works in two steps:
 1.  Open Excel invisibly via win32com ─ returning the workbook handle.
 2.  Either pull a cell value or copy an arbitrary range as a bitmap which is
     then written to a temporary **Enhanced Metafile** (.emf) that Word /
-    PowerPoint can embed loss‑lessly.
+    PowerPoint can embed losslessly.
 
 The implementation is careful to clean Excel up even when things go wrong and
 tries to survive the flaky clipboard behaviour some Windows builds exhibit.
@@ -54,6 +54,7 @@ def _open_excel(path: str):
     Excel COM is initialized at the module level, so we don't need to
     initialize it again here.
     """
+    xl = None
     try:
         xl = win32.Dispatch("Excel.Application")
         try:
@@ -68,6 +69,11 @@ def _open_excel(path: str):
         wb = xl.Workbooks.Open(path, ReadOnly=True)
         return xl, wb
     except Exception as e:
+        # ensure any created Excel instance is cleaned up on failure
+        try:
+            xl.Quit()
+        except Exception:
+            pass
         logger.error(f"Failed to open Excel: {e}")
         raise
 
@@ -149,7 +155,8 @@ def copy_range_as_emf(
         If the clipboard never receives an image of the copied range.
     """
     # Use a secure temporary file
-    tmp_path = Path(tempfile.mktemp(suffix=".emf"))
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".emf") as f:
+        tmp_path = Path(f.name)
     
     # Track if we succeeded
     success = False

--- a/src/gslide/word_writer.py
+++ b/src/gslide/word_writer.py
@@ -83,3 +83,55 @@ def write_to_bookmark(
 
 # Backwards-compatible alias
 write_value_to_bookmark = write_to_bookmark
+
+
+def paste_image_at_bookmark(
+    doc_path: str,
+    bookmark: str,
+    img_path: str,
+    *,
+    word_app: win32.Dispatch | None = None,
+    doc=None,
+    readonly_template: bool = True,
+    width_pts: int | None = None,
+) -> None:
+    """Insert an image at a Word *bookmark* and re-create the bookmark."""
+    own_session = word_app is None
+    if own_session:
+        word_app, doc = _open_word(doc_path, readonly_template)
+
+    try:
+        if not doc.Bookmarks.Exists(bookmark):
+            logging.warning(f"Bookmark '{bookmark}' not found → skipping")
+            return
+
+        rng = doc.Bookmarks(bookmark).Range
+        shape = rng.InlineShapes.AddPicture(img_path, LinkToFile=False, SaveWithDocument=True)
+        if width_pts is not None:
+            shape.LockAspectRatio = True
+            shape.Width = width_pts
+
+        doc.Bookmarks.Add(bookmark, shape.Range)
+        logging.info(f"Inserted image {img_path!r} into bookmark '{bookmark}'")
+
+    except pythoncom.com_error as e:
+        logging.warning(f"COM error on bookmark '{bookmark}': {e}")
+    except Exception as e:
+        logging.warning(f"Unexpected error on bookmark '{bookmark}': {e}")
+    finally:
+        if own_session:
+            try:
+                if readonly_template:
+                    doc.SaveAs2(doc_path)
+                else:
+                    doc.Save()
+            except Exception:
+                pass
+            try:
+                doc.Close(False)
+            except Exception:
+                pass
+            try:
+                word_app.Quit()
+            except Exception:
+                pass

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,14 @@
+from run_value_into_word import format_number_as_words, format_number
+
+
+def test_format_number_as_words():
+    assert format_number_as_words(6800000) == "(Six Million Eight Hundred Thousand Dollars)"
+
+
+def test_format_number_default():
+    assert format_number(1500, None) == "1,500"
+
+
+def test_format_number_custom():
+    assert format_number(123.456, "{:.2f}") == "123.46"
+


### PR DESCRIPTION
## Summary
- fix typo in `excel_reader` docstring
- cleanup Excel instance on `_open_excel` failure
- ensure secure temporary files for EMF exports
- implement `paste_image_at_bookmark` for inserting images
- add scripts `excel_charts_to_word.py` and `excel_tables_to_word.py`
- add unit tests for number formatting utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845efc8d188832980d2d181618a4aad